### PR TITLE
Cl/initial idat conversion INF-434

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:20.04
+
+# Install aws cli
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y --quiet --assume-yes --no-install-recommends  \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        groff \
+        less \
+        awscli \
+        icu-devtools \
+        wget \
+        python2 gcc python2-dev \
+        libbz2-dev make zlib1g-dev libncurses5-dev libncursesw5-dev liblzma-dev \
+        git \
+    && pip3 install --upgrade pip \
+    && apt-get clean
+
+# Install htslib
+ARG htsversion=1.3
+RUN curl -L https://github.com/samtools/htslib/releases/download/${htsversion}/htslib-${htsversion}.tar.bz2 | tar xj && \
+    (cd htslib-${htsversion} && ./configure --enable-plugins --with-plugin-path='$(libexecdir)/htslib:/usr/libexec/htslib' && make install) && \
+    ldconfig && \
+    curl -L https://github.com/samtools/samtools/releases/download/${htsversion}/samtools-${htsversion}.tar.bz2 | tar xj && \
+    (cd samtools-${htsversion} && ./configure --with-htslib=system && make install) && \
+    curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}/bcftools-${htsversion}.tar.bz2 | tar xj && \
+    (cd bcftools-${htsversion} && ./configure --enable-libgsl --enable-perl-filters --with-htslib=system && make install) && \
+    git clone --depth 1 git://github.com/samtools/htslib-plugins && \
+    (cd htslib-plugins && make PLUGINS='hfile_cip.so hfile_mmap.so' install)
+
+# Install ILMN gtc to vcf (note tha hstlib 1.3 is required for pysam 0.9.0, which is the pinned version for ILMN gtc to vcf)
+# However, calvin got things to install with hts lib 1.9
+RUN python get-pip.py && \
+    pip2 install numpy==1.11.2 pyvcf==0.6.8 pysam==0.9.0 && \
+    git clone https://github.com/Illumina/GTCtoVCF.git
+    
+
+# Install ILMN IAAP CLI for idat to gtc conversion
+RUN --mount=type=secret,id=awscredentials,target=/root/.aws/credentials \
+    export AWS_PROFILE=prod && \
+    export AWS_CONFIG_FILE=/root/.aws/credentials && \
+    cd $HOME && \
+    aws s3 cp s3://scratch-embark/iaap/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7.tar.gz . && \
+    tar -xf $HOME/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7.tar.gz && \
+    chmod +x $HOME/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7/iaap-cli/iaap-cli && \
+    rm $HOME/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7.tar.gz
+
+ENV PATH="/root/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7/iaap-cli:$PATH"
+
+# Install picard for gtc to vcf/bcf conversion
+# Note: This doesn't work, only supports human
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk && \
+    apt-get install -y ant && \
+    wget https://github.com/broadinstitute/picard/releases/download/2.26.7/picard.jar && \
+    apt-get clean;
+
+ENV AWS_CONFIG_FILE=/root/.aws/config
+ENV AWS_PROFILE=prod
+
+# Build this repo into container
+ADD ./* /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,27 +20,26 @@ RUN apt-get update && \
     && apt-get clean
 
 # Install htslib
-ARG htsversion=1.3
+# Note bcftools has 1.3.1 patch version which is needed to install correctly 
+ENV htsversion=1.3
 RUN curl -L https://github.com/samtools/htslib/releases/download/${htsversion}/htslib-${htsversion}.tar.bz2 | tar xj && \
     (cd htslib-${htsversion} && ./configure --enable-plugins --with-plugin-path='$(libexecdir)/htslib:/usr/libexec/htslib' && make install) && \
-    ldconfig
-    # Disabling these for now because they aren't needed and somethign didn't install correctly
-    # curl -L https://github.com/samtools/samtools/releases/download/${htsversion}/samtools-${htsversion}.tar.bz2 | tar xj && \
-    # (cd samtools-${htsversion} && ./configure --with-htslib=system && make install) && \
-    # curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}/bcftools-${htsversion}.tar.bz2 | tar xj && \
-    # (cd bcftools-${htsversion} && ./configure --enable-libgsl --enable-perl-filters --with-htslib=system && make install) && \
+    ldconfig && \
+    curl -L https://github.com/samtools/samtools/releases/download/${htsversion}/samtools-${htsversion}.tar.bz2 | tar xj && \
+    (cd samtools-${htsversion} && ./configure --with-htslib=system && make install) && \
+    curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}.1/bcftools-${htsversion}.1.tar.bz2 | tar xj && \
+    (cd bcftools-${htsversion}.1 && make plugins && make HTSDIR=/htslib-${htsversion} install)
     # git clone --depth 1 git://github.com/samtools/htslib-plugins && \
     # (cd htslib-plugins && make PLUGINS='hfile_cip.so hfile_mmap.so' install)
 
-# Install ILMN gtc to vcf (note tha hstlib 1.3 is required for pysam 0.9.0, which is the pinned version for ILMN gtc to vcf)
-# However, calvin got things to install with hts lib 1.9
+# # Install ILMN gtc to vcf (note tha hstlib 1.3 is required for pysam 0.9.0, which is the pinned version for ILMN gtc to vcf)
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
     python2 get-pip.py && \
     pip2 install numpy==1.11.2 pyvcf==0.6.8 pysam==0.9.0 && \
     git clone https://github.com/Illumina/GTCtoVCF.git
     
 
-# Install ILMN IAAP CLI for idat to gtc conversion
+# # Install ILMN IAAP CLI for idat to gtc conversion
 RUN --mount=type=secret,id=awscredentials,target=/root/.aws/credentials \
     export AWS_PROFILE=prod && \
     export AWS_CONFIG_FILE=/root/.aws/credentials && \
@@ -52,16 +51,20 @@ RUN --mount=type=secret,id=awscredentials,target=/root/.aws/credentials \
 
 ENV PATH="/root/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7/iaap-cli:$PATH"
 
-# Install picard for gtc to vcf/bcf conversion
-# Note: This doesn't work, only supports human
+# # Install picard for gtc to vcf/bcf conversion
+# # Note: This doesn't work, only supports human
 RUN apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     apt-get install -y ant && \
     wget https://github.com/broadinstitute/picard/releases/download/2.26.7/picard.jar && \
     apt-get clean;
 
+# Add bwa mem to support strand identification
+RUN git clone https://github.com/lh3/bwa.git && \
+    cd bwa; make
+
 ENV AWS_CONFIG_FILE=/root/.aws/config
 ENV AWS_PROFILE=prod
 
-# Build this repo into container
+# # Build this repo into container
 ADD ./* /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,7 @@ RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
     
 
 # # Install ILMN IAAP CLI for idat to gtc conversion
-RUN --mount=type=secret,id=awscredentials,target=/root/.aws/credentials \
-    export AWS_PROFILE=prod && \
-    export AWS_CONFIG_FILE=/root/.aws/credentials && \
+RUN --mount=type=secret,id=awscredentials,uid=0000 export AWS_CONFIG_FILE=/run/secrets/awscredentials && \
     cd $HOME && \
     aws s3 cp s3://scratch-embark/iaap/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7.tar.gz . && \
     tar -xf $HOME/iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install aws cli
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive && \
@@ -14,25 +16,26 @@ RUN apt-get update && \
         wget \
         python2 gcc python2-dev \
         libbz2-dev make zlib1g-dev libncurses5-dev libncursesw5-dev liblzma-dev \
-        git \
-    && pip3 install --upgrade pip \
+        git curl \
     && apt-get clean
 
 # Install htslib
 ARG htsversion=1.3
 RUN curl -L https://github.com/samtools/htslib/releases/download/${htsversion}/htslib-${htsversion}.tar.bz2 | tar xj && \
     (cd htslib-${htsversion} && ./configure --enable-plugins --with-plugin-path='$(libexecdir)/htslib:/usr/libexec/htslib' && make install) && \
-    ldconfig && \
-    curl -L https://github.com/samtools/samtools/releases/download/${htsversion}/samtools-${htsversion}.tar.bz2 | tar xj && \
-    (cd samtools-${htsversion} && ./configure --with-htslib=system && make install) && \
-    curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}/bcftools-${htsversion}.tar.bz2 | tar xj && \
-    (cd bcftools-${htsversion} && ./configure --enable-libgsl --enable-perl-filters --with-htslib=system && make install) && \
-    git clone --depth 1 git://github.com/samtools/htslib-plugins && \
-    (cd htslib-plugins && make PLUGINS='hfile_cip.so hfile_mmap.so' install)
+    ldconfig
+    # Disabling these for now because they aren't needed and somethign didn't install correctly
+    # curl -L https://github.com/samtools/samtools/releases/download/${htsversion}/samtools-${htsversion}.tar.bz2 | tar xj && \
+    # (cd samtools-${htsversion} && ./configure --with-htslib=system && make install) && \
+    # curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}/bcftools-${htsversion}.tar.bz2 | tar xj && \
+    # (cd bcftools-${htsversion} && ./configure --enable-libgsl --enable-perl-filters --with-htslib=system && make install) && \
+    # git clone --depth 1 git://github.com/samtools/htslib-plugins && \
+    # (cd htslib-plugins && make PLUGINS='hfile_cip.so hfile_mmap.so' install)
 
 # Install ILMN gtc to vcf (note tha hstlib 1.3 is required for pysam 0.9.0, which is the pinned version for ILMN gtc to vcf)
 # However, calvin got things to install with hts lib 1.9
-RUN python get-pip.py && \
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
+    python2 get-pip.py && \
     pip2 install numpy==1.11.2 pyvcf==0.6.8 pysam==0.9.0 && \
     git clone https://github.com/Illumina/GTCtoVCF.git
     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iaap-genotype-calling
 
 
-`docker build --secret id=awscredentials,src=$(echo ~)/.aws/config . -t 074763112859.dkr.ecr.us-east-1.amazonaws.com/embark/iaap:latest`
+`docker build --secret id=awscredentials,src=$(echo ~)/.aws/credentials . -t 074763112859.dkr.ecr.us-east-1.amazonaws.com/embark/iaap:latest`
 
-`docker run -it -v $HOME/.aws/config:/root/.aws/config:ro 074763112859.dkr.ecr.us-east-1.amazonaws.com/embark/iaap:latest`
+`docker run -it -v $HOME/.aws:/root/.aws:ro 074763112859.dkr.ecr.us-east-1.amazonaws.com/embark/iaap:latest`

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # iaap-genotype-calling
+
+
+`docker build --secret id=awscredentials,src=$(echo ~)/.aws/config . -t 074763112859.dkr.ecr.us-east-1.amazonaws.com/embark/iaap:latest`
+
+`docker run -it -v $HOME/.aws/config:/root/.aws/config:ro 074763112859.dkr.ecr.us-east-1.amazonaws.com/embark/iaap:latest`

--- a/analyze_gtc.py
+++ b/analyze_gtc.py
@@ -1,0 +1,3 @@
+from IlluminaBeadArrayFiles import GenotypeCalls
+
+gc = GenotypeCalls("/outputs/205881370069_R11C02.gtc")

--- a/run_gencall.sh
+++ b/run_gencall.sh
@@ -12,6 +12,7 @@ iaap-cli gencall Embark_2021_260k_20063270_A1.bpm Embark_2021_260k_20063270_A1_2
 aws s3 sync outputs s3://scratch-embark/iaap-test/
 # Grab canfam 4 as reference data
 aws s3 cp s3://embark-data-drops/canFam4/canFam4.fa .
+aws s3 cp s3://embark-data-drops/canFam4/canFam4.fa.fai .
 
 # Convert outputs to vcf
 # Didn't work, only human supported 
@@ -23,9 +24,19 @@ aws s3 cp s3://embark-data-drops/canFam4/canFam4.fa .
 #       CLUSTER_FILE=Embark_2021_260k_20063270_A1_20211122.egt \
 #       ILLUMINA_BEAD_POOL_MANIFEST_FILE=Embark_2021_260k_20063270_A1.bpm \
 #       SAMPLE_ALIAS=test_alias
-python gtc_to_vcf.py \
+
+# Insert ref strand data artificially into csv
+# To do this, add a + into every row in the 19th column
+#however, the first row is a header, so use sed to replace the plus in the first row with the column name
+# TODO: Bug MarkH to get a manifest that has this column
+awk -F"," 'BEGIN { OFS = "," } {$19="+"; print}' /Embark_2021_260k_20063270_A1.csv > /Embark_2021_260k_20063270_A1_tweaked.csv
+sed 's/TopGenomicSeq,+/TopGenomicSeq,refstrand/' /Embark_2021_260k_20063270_A1_tweaked.csv > /Embark_2021_260k_20063270_A1_tweaked2.csv
+
+# Also note that gtc_to_vcf.py expects contigs to be named like "8" instead of "chr8"
+python2 GTCtoVCF/gtc_to_vcf.py \
     --gtc-paths /outputs/205881370069_R11C02.gtc \
-    --manifest-file /Embark_2021_260k_20063270_A1.csv \
-    --genome-fasta-file /canFam4.fa
+    --manifest-file /Embark_2021_260k_20063270_A1_tweaked2.csv \
+    --genome-fasta-file /canFam4.fa \
+    --skip-indels # Skip indels required when using bpm manifest. Need extended csv manifest.
     
 aws s3 sync output.vcf s3://scratch-embark/iaap-test/

--- a/run_gencall.sh
+++ b/run_gencall.sh
@@ -1,0 +1,31 @@
+# Download cluster/probe metadata
+aws s3 cp s3://genotype-datasets/marker_files/v6_chip_production_probe_lists/Embark_2021_260k_20063270_A1_20211122.egt .
+aws s3 cp s3://genotype-datasets/marker_files/v6_chip_production_probe_lists/Embark_2021_260k_20063270_A1.bpm .
+aws s3 cp s3://genotype-datasets/marker_files/v6_chip_production_probe_lists/Embark_2021_260k_20063270_A1.csv .
+aws s3 sync s3://illumina-embark-sample-level-deliveries/2021-12-14/31001805234805/IDATs/205881370069/ idats
+
+# Copy the ILMN data to the test bucket for safekeeping
+aws s3 sync s3://illumina-embark-sample-level-deliveries/2021-12-14/31001805234805 s3://scratch-embark/iaap-test/
+
+# Download an example idat from a new dog
+iaap-cli gencall Embark_2021_260k_20063270_A1.bpm Embark_2021_260k_20063270_A1_20211122.egt outputs -f idats -g
+aws s3 sync outputs s3://scratch-embark/iaap-test/
+# Grab canfam 4 as reference data
+aws s3 cp s3://embark-data-drops/canFam4/canFam4.fa .
+
+# Convert outputs to vcf
+# Didn't work, only human supported 
+# java -jar picard.jar GtcToVcf \
+#       INPUT=outputs/205881370069_R11C02.gtc \
+#       REFERENCE_SEQUENCE=canFam4.fa \
+#       OUTPUT=output.vcf \
+#       EXTENDED_ILLUMINA_MANIFEST=Embark_2021_260k_20063270_A1.csv \
+#       CLUSTER_FILE=Embark_2021_260k_20063270_A1_20211122.egt \
+#       ILLUMINA_BEAD_POOL_MANIFEST_FILE=Embark_2021_260k_20063270_A1.bpm \
+#       SAMPLE_ALIAS=test_alias
+python gtc_to_vcf.py \
+    --gtc-paths /outputs/205881370069_R11C02.gtc \
+    --manifest-file /Embark_2021_260k_20063270_A1.csv \
+    --genome-fasta-file /canFam4.fa
+    
+aws s3 sync output.vcf s3://scratch-embark/iaap-test/

--- a/run_gencall.sh
+++ b/run_gencall.sh
@@ -13,6 +13,9 @@ aws s3 sync outputs s3://scratch-embark/iaap-test/
 # Grab canfam 4 as reference data
 aws s3 cp s3://embark-data-drops/canFam4/canFam4.fa .
 aws s3 cp s3://embark-data-drops/canFam4/canFam4.fa.fai .
+# Rename chrX to X, which is what ILMN expects based on hg19
+cat canFam4.fa | sed -r 's/chr([0-9XM]*)/\1/g' > canFam4.fa
+cat canFam4.fa.fai | sed -r 's/chr([0-9XM]*)/\1/g' > canFam4.fa.fai
 
 # Convert outputs to vcf
 # Didn't work, only human supported 

--- a/run_gencall.sh
+++ b/run_gencall.sh
@@ -2,14 +2,14 @@
 aws s3 cp s3://genotype-datasets/marker_files/v6_chip_production_probe_lists/Embark_2021_260k_20063270_A1_20211122.egt .
 aws s3 cp s3://genotype-datasets/marker_files/v6_chip_production_probe_lists/Embark_2021_260k_20063270_A1.bpm .
 aws s3 cp s3://genotype-datasets/marker_files/v6_chip_production_probe_lists/Embark_2021_260k_20063270_A1.csv .
-aws s3 sync s3://illumina-embark-sample-level-deliveries/2021-12-14/31001805234805/IDATs/205881370069/ idats
+aws s3 sync s3://illumina-embark-sample-level-deliveries/2022-01-10/31211050209140/IDATs/205885920066/ idats
 
 # Copy the ILMN data to the test bucket for safekeeping
-aws s3 sync s3://illumina-embark-sample-level-deliveries/2021-12-14/31001805234805 s3://scratch-embark/iaap-test/
+aws s3 sync s3://illumina-embark-sample-level-deliveries/2022-01-10/31211050209140 s3://scratch-embark/iaap-test/
 
 # Download an example idat from a new dog
 iaap-cli gencall Embark_2021_260k_20063270_A1.bpm Embark_2021_260k_20063270_A1_20211122.egt outputs -f idats -g
-aws s3 sync outputs s3://scratch-embark/iaap-test/
+aws s3 sync outputs s3://scratch-embark/iaap-test/31211050209140/
 
 # Grab canfam 4 as reference data
 aws s3 cp s3://embark-data-drops/canFam3/canFam3.1_and_SRY.fa .
@@ -19,11 +19,36 @@ aws s3 cp s3://embark-data-drops/canFam3/canFam3.1_and_SRY.fa.bwt .
 aws s3 cp s3://embark-data-drops/canFam3/canFam3.1_and_SRY.fa.dict .
 aws s3 cp s3://embark-data-drops/canFam3/canFam3.1_and_SRY.fa.sa .
 
+# Rename chrX to X, chr10 to 10, Dog_Y to Y etc., which is what ILMN expects based on hg19
+cat canFam3.1_and_SRY.fa | sed -r 's/(chr|Dog_)([0-9YXM]+)/\2/g' > canFam3.1_and_SRY_cleaned.fa
+cat canFam3.1_and_SRY.fa.fai | sed -r 's/(chr|Dog_)([0-9YXM]+)/\2/g' > canFam3.1_and_SRY_cleaned.fa.fai
 
-# Rename chrX to X, which is what ILMN expects based on hg19
-cat canFam3.1_and_SRY.fa | sed -r 's/chr([0-9YXM]*)/\1/g' > canFam3.1_and_SRY.fa
-cat canFam3.1_and_SRY.fa.fai | sed -r 's/chr([0-9YXM]*)/\1/g' > canFam3.1_and_SRY.fa.fai
+# Extract strand information
+pip3 install pandas
+mkdir pandas_tweaked
+# class SourceStrand:
+#     Unknown = 0 = U
+#     Forward = 1  = +
+#     Reverse = 2  = -
 
+python3 -c """
+import pandas as pd
+df=pd.read_csv('Embark_2021_260k_20063270_A1.csv', skiprows=7)
+df[['ILMNStrand_from_id', 'refstrand']] = df['IlmnID'].str.extract('_([BTPM])_([FR])')
+df['MapInfo'] = df['MapInfo'].fillna(0).astype(int)
+df['refstrand'] = df['refstrand'].map({'F': '+', 'R': '-'}).fillna('U')
+df.to_csv('pandas_tweaked/Embark_2021_260k_20063270_A1.csv', index=False)
+"""
+python2 GTCtoVCF/gtc_to_vcf.py \
+    --gtc-paths /outputs/205885920066_R05C01.gtc \
+    --manifest-file /pandas_tweaked/Embark_2021_260k_20063270_A1.csv \
+    --genome-fasta-file /canFam3.1_and_SRY_cleaned.fa \
+    --log-file gtc_to_vcf.log \
+    --include-attributes {GT,GQ,BAF,LRR}
+
+
+# Everything from here down is only needed if you want to use BWA intead of the manifest for alignment
+# information. You should probably do this to double check ILMN's alignment information/refstrand
 
 # Cut header and footer
 tail -n +9 Embark_2021_260k_20063270_A1.csv > Embark_2021_260k_20063270_A1_no_header.csv
@@ -72,7 +97,7 @@ sed 's/TopGenomicSeq,+/TopGenomicSeq,refstrand/' /Embark_2021_260k_20063270_A1_t
 python2 GTCtoVCF/gtc_to_vcf.py \
     --gtc-paths /outputs/205881370069_R11C02.gtc \
     --manifest-file /Embark_2021_260k_20063270_A1_tweaked2.csv \
-    --genome-fasta-file /canFam3.1_and_SRY.fa \
+    --genome-fasta-file /canFam3.1_and_SRY_cleaned.fa \
     --skip-indels # Skip indels required when using bpm manifest. Need extended csv manifest.
     
 aws s3 sync output.vcf s3://scratch-embark/iaap-test/


### PR DESCRIPTION
Working idat to gtc conversion. gtc to vcf is still problematic, largely due to oddities with reference genome.

Problems to be resolved:

Chromosome Y contig is absent from canfam4? Oh right its Tasha! Dammit
```
>>> fa = pysam.FastaFile("canFam4.fa")
>>> "chrY" in fa.references
False
>>> [r for r in fa.references if "chrUn" not in r]
['chr1', 'chr10', 'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16', 'chr17', 'chr18', 'chr19', 'chr2', 'chr20', 'chr21', 'chr22', 'chr23', 'chr24', 'chr25', 'chr26', 'chr27', 'chr28', 'chr29', 'chr3', 'chr30', 'chr31', 'chr32', 'chr33', 'chr34', 'chr35', 'chr36', 'chr37', 'chr38', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8', 'chr9', 'chrM', 'chrX']
```

Also, refstrand is missing from our csv manifest. Need to check with AaronS/Andrea/MarkH tomorrow, maybe we can get that? for now, just labeled all probes as + strand, since I don't want to figure out TOP/BOTTOM. Maybe genome studio can output this?